### PR TITLE
Fix Enumerating ActiveModel::Errors as a hash has been deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /spec/dummy/
 /tmp/
 gemfiles/*.lock
+.idea

--- a/lib/active_admin/reform/active_record.rb
+++ b/lib/active_admin/reform/active_record.rb
@@ -25,7 +25,11 @@ module ActiveAdmin
         include ::Reform::Form::ModelReflections
         include ::Reform::Form::ActiveRecord
 
-        validate { model.errors.each { |key, error| errors.add key, error } }
+        if ::ActiveRecord::VERSION::MAJOR < 6
+          validate { model.errors.each { |key, error| errors.add key, error } }
+        else
+          validate { model.errors.each { |error| errors.add error.attribute, error.message } }
+        end
 
         class << self
           def reflect_on_association(name)


### PR DESCRIPTION
Fixing the deprecate warning:

```
DEPRECATION WARNING: Enumerating ActiveModel::Errors as a hash has been deprecated.
In Rails 6.1, `errors` is an array of Error objects,
therefore it should be accessed by a block with a single block
parameter like this:

person.errors.each do |error|
  attribute = error.attribute
  message = error.message
end

You are passing a block expecting two parameters,
so the old hash behavior is simulated. As this is deprecated,
this will result in an ArgumentError in Rails 7.0.


```